### PR TITLE
Subscription options fixes

### DIFF
--- a/lib/stan.js
+++ b/lib/stan.js
@@ -793,6 +793,7 @@ SubscriptionOptions.prototype.setStartAt = function(startPosition) {
 SubscriptionOptions.prototype.setStartAtSequence = function(sequence) {
   this.startPosition = proto.StartPosition.SEQUENCE_START;
   this.startSequence = sequence;
+  return this;
 };
 
 
@@ -803,7 +804,7 @@ SubscriptionOptions.prototype.setStartAtSequence = function(sequence) {
 SubscriptionOptions.prototype.setStartTime = function(date) {
   this.startPosition = proto.StartPosition.TIME_DELTA_START;
   // server expects values in ns
-  this.startTime = date.millis() * 1000000;
+  this.startTime = date.getTime() * 1000000;
   return this;
 };
 
@@ -814,7 +815,7 @@ SubscriptionOptions.prototype.setStartTime = function(date) {
 SubscriptionOptions.prototype.setStartAtTimeDelta = function(millis) {
   this.startPosition = proto.StartPosition.TIME_DELTA_START;
   //noinspection JSUnresolvedFunction
-  var now = new Date().millis();
+  var now = new Date().getTime();
   // server expects values in ns
   this.startTime = (now - millis) * 1000000;
   return this;

--- a/lib/stan.js
+++ b/lib/stan.js
@@ -21,7 +21,7 @@ var util = require('util'),
 /**
  * Constants
  */
-var VERSION = '0.0.3',
+var VERSION = '0.0.4',
 DEFAULT_PORT = 4222,
 DEFAULT_PRE = 'nats://localhost:',
 DEFAULT_URI = DEFAULT_PRE + DEFAULT_PORT,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-nats-streaming",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Node.js client for NATS Streaming, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",

--- a/test/basics.js
+++ b/test/basics.js
@@ -57,6 +57,25 @@ describe('Basics', function () {
     });
   });
 
+  it('subscription options should allow chaining', function (done) {
+    var stan = STAN.connect(cluster, nuid.next(), PORT);
+    stan.on('connect', function () {
+      var so = stan.subscriptionOptions();
+      so.setStartAt(STAN.StartPosition.FIRST).should.be.equal(so);
+      so.setMaxInFlight(100).should.be.equal(so);
+      so.setAckWait(1000).should.be.equal(so);
+      so.setStartAt(1000).should.be.equal(so);
+      so.setStartAtSequence(1000).should.be.equal(so);
+      so.setStartTime(new Date()).should.be.equal(so);
+      so.setStartAtTimeDelta(1000).should.be.equal(so);
+      so.setStartWithLastReceived().should.be.equal(so);
+      so.setDeliverAllAvailable().should.be.equal(so);
+      so.setManualAckMode(true).should.be.equal(so);
+      so.setDurableName('foo').should.be.equal(so);
+      done();
+    });
+  });
+
   it('should do publishAsync', function (done) {
     var stan = STAN.connect(cluster, nuid.next(), PORT);
     var connected = false;


### PR DESCRIPTION
3 embarrassing bugs:
 - Missing return from subscriptionOptions#setStartAtSequence didn't return itself to allow chaining.
 - Calls to `date.millis()` instead of `date.getTime()`

Resolves #10 
