### PR TITLE
[FIX #15] Added Message#ack() to typings, and bumped versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,6 @@ durableSub.on('message', function(msg) {
 
 Subscriptions with the same queue name will form a queue group. Each message is only delivered to a single subscriber per queue group. You can have as many queue groups as you wish. Normal subscribers are not affected by queue group semantics.
 
-Note that you cannot have a queue group that is also a durable subscriber.
-
 ```javascript
     var opts = stan.subscriptionOptions();
     opts.setStartWithLastReceived();

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,6 +66,12 @@ declare class Message {
      * Returns an optional IEEE CRC32 checksum
      */
     getCrc32():number;
+
+    /**
+     * Acks the message, note this method shouldn't be called unless
+     * the manualAcks option was set on the subscription.
+     */
+    ack();
 }
 
 

--- a/lib/stan.js
+++ b/lib/stan.js
@@ -21,7 +21,7 @@ var util = require('util'),
 /**
  * Constants
  */
-var VERSION = '0.0.6',
+var VERSION = '0.0.8',
 DEFAULT_PORT = 4222,
 DEFAULT_PRE = 'nats://localhost:',
 DEFAULT_URI = DEFAULT_PRE + DEFAULT_PORT,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-nats-streaming",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "description": "Node.js client for NATS Streaming, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",


### PR DESCRIPTION
[CHANGED] Removed statement that NATS Streaming clients cannot be part of a queuegroup and be durable, as the server has relaxed that limitation.