### PR TITLE
Fix Supported Node Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cover": "istanbul cover _mocha"
   },
   "engines": {
-    "node": ">= .10.x"
+    "node": ">= 0.10.x"
   },
   "dependencies": {
     "google-protobuf": "^3.0.0-alpha.6.2",


### PR DESCRIPTION
Not sure about npm, but the Node engine version isn't recognized as valid under Yarn. Using the full version fixes this.

```
% yarn add node-nats-streaming
yarn add v0.17.2
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
error node-nats-streaming@0.0.14: The engine "node" is incompatible with this module. Expected version ">= .10.x".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

```
% node --version
v6.9.0
```