### PR TITLE
[FIX] #35 - Acks are possible after a subscription is closed/unsubscribed

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,11 @@ declare class Message {
 
 declare class Subscription extends events.EventEmitter {
     /**
+     * Returns true if the subscription has been closed or unsubscribed from.
+     */
+    isClosed():boolean;
+
+    /**
      * Unregisters the subscription from the streaming server.
      */
     unsubscribe();

--- a/lib/stan.js
+++ b/lib/stan.js
@@ -21,7 +21,7 @@ var util = require('util'),
 /**
  * Constants
  */
-var VERSION = '0.0.16',
+var VERSION = '0.0.18',
 DEFAULT_PORT = 4222,
 DEFAULT_PRE = 'nats://localhost:',
 DEFAULT_URI = DEFAULT_PRE + DEFAULT_PORT,
@@ -38,6 +38,7 @@ BAD_CLIENT_ID = 'stan: client ID must be supplied',
 ACK_TIMEOUT = 'stan: publish ack timeout',
 MAX_FLIGHT_LIMIT_REACHED = 'stan: max in flight reached.',
 CONN_CLOSED = 'stan: Connection closed',
+BAD_SUBSCRIPTION = 'stan: invalid subscription',
 BINARY_ENCODING_REQUIRED = 'stan: NATS connection encoding must be \'binary\'.';
 
 /**
@@ -576,14 +577,30 @@ function Subscription(stanConnection, subject, qGroup, inbox, opts) {
  */
 
 util.inherits(Subscription, events.EventEmitter);
+
+/**
+ * Returns true if the subscription has been closed or unsubscribed from.
+ * @returns {boolean}
+ */
+Subscription.prototype.isClosed = function() {
+  return this.stanConnection === undefined;
+};
+
 /**
  * Unregisters the subscription from the streaming server. You cannot unsubscribe
  * from the server unless the Subscription#ready notification has already fired.
  * @fires Subscription#error({Error}, Subscription#unsubscribed, Subscription#timeout({Error}
  */
 Subscription.prototype.unsubscribe = function() {
+  if(this.isClosed()) {
+    this.emit('error', new Error(BAD_SUBSCRIPTION));
+  }
+
+  var that = this;
   var sc = this.stanConnection;
+  delete this.stanConnection;
   delete sc.subMap[this.inbox];
+
   if(sc.isClosed()) {
     this.emit('error', new Error(CONN_CLOSED));
     return;
@@ -596,7 +613,6 @@ Subscription.prototype.unsubscribe = function() {
   ur.setSubject(this.subject);
   ur.setInbox(this.ackInbox);
 
-  var that = this;
   var sid = sc.nc.request(sc.unsubRequests, new Buffer(ur.serializeBinary()), {'max': 1}, function (msg) {
     //noinspection JSUnresolvedVariable
     var r = proto.SubscriptionResponse.deserializeBinary(new Buffer(msg, 'binary').toByteArray());
@@ -741,7 +757,7 @@ Message.prototype.maybeAutoAck = function() {
  * the manualAcks option was set on the subscription.
  */
 Message.prototype.ack = function() {
-  if(!this.stanClient.isClosed()) {
+  if(!this.subscription.isClosed()) {
     var ack = new proto.Ack();
     ack.setSubject(this.getSubject());
     ack.setSequence(this.getSequence());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-nats-streaming",
-  "version": "0.0.16",
+  "version": "0.0.18",
   "description": "Node.js client for NATS Streaming, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",

--- a/test/basics.js
+++ b/test/basics.js
@@ -376,7 +376,7 @@ describe('Basics', function () {
     });
   });
 
-  it('subscribe twice is invalid', function (done) {
+  it('unsubscribe twice is invalid', function (done) {
     var stan = STAN.connect(cluster, nuid.next(), PORT);
     stan.on('connect', function () {
       var sub = stan.subscribe(nuid.next());

--- a/test/basics.js
+++ b/test/basics.js
@@ -394,6 +394,22 @@ describe('Basics', function () {
     });
   });
 
+  it('unsubscribe marks it closed', function (done) {
+    var stan = STAN.connect(cluster, nuid.next(), PORT);
+    stan.on('connect', function () {
+      var sub = stan.subscribe(nuid.next());
+      sub.on('ready', function () {
+        sub.unsubscribe();
+        if(! sub.isClosed()) {
+          done("Subscription should have been closed");
+        }
+      });
+      sub.on('unsubscribed', function () {
+        done();
+      });
+    });
+  });
+
   it('subscribe starting on second', function (done) {
     var stan = STAN.connect(cluster, nuid.next(), PORT);
     var subj = nuid.next();


### PR DESCRIPTION
The fix simply deletes the stanClient associated with the subscription on the unsubscribe. Adding checks to ack() make it a noop. Also tidied the emitting of an error on double unsubscribe/close.