### PR TITLE
package.json: fix nodejs engine dependency version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:unit": "mkdir -p reports/ && NODE_ENV=test multi='spec=- xunit=reports/mocha-xunit.xml' istanbul cover _mocha -- -R mocha-multi --timeout 10000 --slow 750 && istanbul check-coverage"
   },
   "engines": {
-    "node": ">= 0.10.x"
+    "node": ">= 0.10.0"
   },
   "dependencies": {
     "google-protobuf": "^3.0.0-alpha.6.2",


### PR DESCRIPTION
In `engines.nodejs` there were mixed two semver range syntaxes `>=' and '0.10.x'. yarn gives precedence to `.x` syntax, therefore refuses to install the package on nodejs 6. I suppose there should be `>= 0.10.0` to keep the meaning and make it installable.