### PR TITLE
Fixing implicit any typing issues

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -71,7 +71,7 @@ declare class Message {
      * Acks the message, note this method shouldn't be called unless
      * the manualAcks option was set on the subscription.
      */
-    ack();
+    ack(): void;
 }
 
 
@@ -84,7 +84,7 @@ declare class Subscription extends events.EventEmitter {
     /**
      * Unregisters the subscription from the streaming server.
      */
-    unsubscribe();
+    unsubscribe(): void;
 
     /**
      * Close removes the subscriber from the server, but unlike the Subscription#unsubscribe(),
@@ -93,7 +93,7 @@ declare class Subscription extends events.EventEmitter {
      * Subscription#error(NO_SERVER_SUPPORT) error. Note that this affects durable clients only.
      * If called on a non-durable subscriber, this is equivalent to Subscription#close()
      */
-    close();
+    close(): void;
 }
 
 /**
@@ -110,7 +110,7 @@ declare class Stan extends events.EventEmitter {
 	/**
 	 * Close the connection to the server.
 	 */
-	close();
+	close(): void;
 
     /**
      * Publishes a message to the streaming server with the specified subject and data.


### PR DESCRIPTION
Small fix for some implicit any type compile errors with typescript. Can work around it by setting `"noImplicitAny": false` in tsconfig.json but I prefer stricter settings.

Fixes the following errors:

```
node_modules/node-nats-streaming/index.d.ts(74,5): error TS7010: 'ack', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/node-nats-streaming/index.d.ts(87,5): error TS7010: 'unsubscribe', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/node-nats-streaming/index.d.ts(96,5): error TS7010: 'close', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/node-nats-streaming/index.d.ts(113,2): error TS7010: 'close', which lacks return-type annotation, implicitly has an 'any' return type.
```

Version: 0.0.25
Typescript version: 2.3.4