### PR TITLE
updating deps, removing wip, fix close

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,14 @@ node_js:
   - "7"
 
 before_script:
-  - wget https://github.com/nats-io/nats-streaming-server/releases/download/v0.3.8/nats-streaming-server-v0.3.8-linux-amd64.zip -O tmp.zip
+  - wget https://github.com/nats-io/nats-streaming-server/releases/download/v0.5.0/nats-streaming-server-v0.5.0-linux-amd64.zip -O tmp.zip
   - unzip tmp.zip
-  - mv nats-streaming-server-v0.3.8-linux-amd64 nats-streaming-server
-  - mv nats-streaming-server/nats-streaming-server-v0.3.8 nats-streaming-server/nats-streaming-server
+  - mv nats-streaming-server-v0.5.0-linux-amd64 nats-streaming-server
+  - mkdir nats-streaming-server/logs
 
 
 after_success:
   - npm run coveralls
+
+after_failure:
+  - cat nats-streaming-server/logs/*.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Work-in-progress] node-nats-streaming - Node.js NATS Streaming Client
+# NATS Streaming - Node.js Client
 
 Node NATS Streaming is an extremely performant, lightweight reliable streaming platform powered by [NATS](http://nats.io) for [Node.js](http://nodejs.org/).
 

--- a/lib/stan.js
+++ b/lib/stan.js
@@ -21,7 +21,7 @@ var util = require('util'),
 /**
  * Constants
  */
-var VERSION = '0.0.25',
+var VERSION = '0.0.26',
 DEFAULT_PORT = 4222,
 DEFAULT_PRE = 'nats://localhost:',
 DEFAULT_URI = DEFAULT_PRE + DEFAULT_PORT,
@@ -317,22 +317,24 @@ Stan.prototype.close = function() {
   //noinspection JSUnresolvedFunction
   var req = new proto.CloseRequest();
   req.setClientId(this.clientID);
-  this.nc.request(this.closeRequests, new Buffer(req.serializeBinary()), {max: 1}, function(msg) {
+  this.nc.requestOne(this.closeRequests, new Buffer(req.serializeBinary()), {}, that.options.connectTimeout, function(msgOrError) {
     var nc = that.nc;
     delete that.nc;
-    nc.flush(function(){
-      if (that.ncOwned) {
-        nc.close();
-        that.emit('close');
-      }
-
-      //noinspection JSUnresolvedVariable
-      var cr = proto.CloseResponse.deserializeBinary(new Buffer(msg, 'binary').toByteArray());
-      var err = cr.getError();
-      if(err && err.length > 0) {
-        that.emit('error', new Error(err));
-      }
-    });
+    //noinspection JSUnresolvedVariable
+    if(msgOrError instanceof nats.NatsError) {
+      that.emit('error', msgOrError);
+    } else {
+        var cr = proto.CloseResponse.deserializeBinary(new Buffer(msgOrError, 'binary').toByteArray());
+        var err = cr.getError();
+        if (err && err.length > 0) {
+            that.emit('error', new Error(err));
+        }
+    }
+    // go closes always
+    if (that.ncOwned) {
+      nc.close();
+      that.emit('close');
+    }
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-nats-streaming",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Node.js client for NATS Streaming, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",
@@ -45,8 +45,8 @@
   },
   "dependencies": {
     "google-protobuf": "^3.0.0-alpha.6.2",
-    "nats": ">= 0.7.10",
-    "nuid": ">=0.6.8"
+    "nats": ">= 0.7.20",
+    "nuid": ">=0.6.14"
   },
   "devDependencies": {
     "jshint": "2.9.x",

--- a/package.json
+++ b/package.json
@@ -44,20 +44,20 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "google-protobuf": "^3.0.0-alpha.6.2",
+    "google-protobuf": "^3.3.0",
     "nats": ">= 0.7.20",
     "nuid": ">=0.6.14"
   },
   "devDependencies": {
-    "jshint": "2.9.x",
-    "jshint-stylish": "2.2.x",
-    "mocha": "3.0.x",
-    "mocha-multi": "0.9.x",
-    "mocha-lcov-reporter": "1.2.x",
-    "dependency-check": "2.6.x",
-    "istanbul": "0.4.x",
     "coveralls": "^2.11.2",
-    "should": ">= 9.0.0"
+    "dependency-check": "2.6.x",
+    "istanbul": "^0.4.5",
+    "jshint": "^2.9.5",
+    "jshint-stylish": "^2.2.1",
+    "mocha": "^3.0.2",
+    "mocha-lcov-reporter": "1.2.x",
+    "mocha-multi": "^0.9.1",
+    "should": "^11.2.1"
   },
   "typings": "./index.d.ts"
 }

--- a/test/support/stan_server_control.js
+++ b/test/support/stan_server_control.js
@@ -5,6 +5,7 @@ var spawn = require('child_process').spawn;
 var net = require('net');
 
 var SERVER = (process.env.TRAVIS) ? 'nats-streaming-server/nats-streaming-server' : 'nats-streaming-server';
+var LOG_DIR = (process.env.TRAVIS) ? 'nats-streaming-server/logs/' : '/tmp/';
 var DEFAULT_PORT = 4222;
 
 exports.start_server = function(port, opt_flags, done) {
@@ -15,7 +16,7 @@ exports.start_server = function(port, opt_flags, done) {
     done = opt_flags;
     opt_flags = null;
   }
-  var flags = ['-p', port];
+  var flags = ['-p', port, '-SDV','-log', LOG_DIR + 'stan_log_'+port+'.log'];
 
   if (opt_flags) {
     flags = flags.concat(opt_flags);

--- a/test/support/stan_server_control.js
+++ b/test/support/stan_server_control.js
@@ -1,11 +1,12 @@
 /* jslint node: true */
 'use strict';
 
-var spawn = require('child_process').spawn;
-var net = require('net');
+var spawn = require('child_process').spawn,
+net = require('net'),
+os = require('os');
 
 var SERVER = (process.env.TRAVIS) ? 'nats-streaming-server/nats-streaming-server' : 'nats-streaming-server';
-var LOG_DIR = (process.env.TRAVIS) ? 'nats-streaming-server/logs/' : '/tmp/';
+var LOG_DIR = (process.env.TRAVIS) ? 'nats-streaming-server/logs/' : os.tmpdir();
 var DEFAULT_PORT = 4222;
 
 exports.start_server = function(port, opt_flags, done) {


### PR DESCRIPTION
- [DOC] Removed WIP from readme
- [VERSION] Bumped to 0.0.26, also bumped min versions for node-nats and node-nuid deps to current ones
- [FIX] If nats close is called, the close is also triggered on stan, but response from close request to stan is waited for. Also request for close is made using a timeout.
- [FIX] Test for reconnect needed to invoke a timeout as the reconnect would ignore the reconnecting client.

- [Updated] nats-streaming-server image pulled for tests.
- [Updated] node-nats and nuid dependencies