### PR TITLE
Fix AckHandlerCallback error type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -115,7 +115,7 @@ declare class Subscription extends events.EventEmitter {
  * @param err - undefined if there is no error processing the message
  * @param guid - the guid correlating the message with the callback invocation.
  */
-interface AckHandlerCallback { (err: Error, guid: string): void; }
+interface AckHandlerCallback { (err: Error | undefined, guid: string): void; }
 
 
 


### PR DESCRIPTION
Currently AckHandlerCallback error parameter is defined with a type `Error` which isn't the correct type when `strictNullChecks` setting is enabled (available since TS 2.0, and generally suggested to be enabled as a good practice). All `null` and `undefined` values are expected to be explicitly stated when they can be passed as a value.