### PR TITLE
Ping documentation and default value for maxReconnectAttempts

### DIFF
--- a/lib/stan.js
+++ b/lib/stan.js
@@ -133,7 +133,8 @@ Stan.prototype.parseOptions = function(opts) {
     maxPubAcksInflight: DEFAULT_MAX_IN_FLIGHT,
     stanEncoding: 'utf8',
     pingInterval: DEFAULT_PING_INTERVAL,
-    pingMaxOut: DEFAULT_PING_MAXOUT
+    pingMaxOut: DEFAULT_PING_MAXOUT,
+    maxReconnectAttempts: -1
   };
 
   if (opts === undefined) {
@@ -307,7 +308,7 @@ Stan.prototype.createConnection = function() {
 
     var discoverSubject = that.options.discoverPrefix + '.' + that.clusterID;
     //noinspection JSUnresolvedFunction
-    that.connId = nuid.next();
+    that.connId = Buffer.from(nuid.next(), "utf8");
     var req = new proto.ConnectRequest();
     req.setClientId(that.clientID);
     req.setHeartbeatInbox(hbInbox);
@@ -571,6 +572,7 @@ Stan.prototype.publish = function(subject, data, ackHandler) {
   //noinspection JSUnresolvedFunction
   var pe = new proto.PubMsg();
   pe.setClientId(this.clientID);
+  pe.setConnId(this.connId);
   pe.setGuid(peGUID);
   pe.setSubject(subject);
   var buf;
@@ -980,6 +982,18 @@ Message.prototype.ack = function() {
     ack.setSequence(this.getSequence());
     this.stanClient.nc.publish(this.subscription.ackInbox, Buffer.from(ack.serializeBinary()));
   }
+};
+
+/**
+ *
+ * @returns {!(string|Uint8Array)}
+ */
+Message.prototype.getClientID = function() {
+  return this.msg.getConnId();
+};
+
+Message.prototype.getConnectionID = function() {
+  return this.msg.getClientId();
 };
 
 

--- a/test/connect.js
+++ b/test/connect.js
@@ -279,7 +279,11 @@ describe('Basic Connectivity', function() {
   it('reconnect should provide stan connection', function (done) {
     // done = DoneSilencer(done);
     this.timeout(15000);
-    var stan = STAN.connect(cluster, nuid.next(), {'url':'nats://localhost:' + PORT, 'reconnectTimeWait':1000});
+    var stan = STAN.connect(cluster, nuid.next(), {
+      url:'nats://localhost:' + PORT,
+      reconnectTimeWait:1000,
+      maxReconnectAttempts: 10
+    });
     var reconnected = false;
     var disconnected = false;
     stan.on('connect', function (sc) {
@@ -308,7 +312,11 @@ describe('Basic Connectivity', function() {
 
   it('nats close, should not close stan', function (done) {
     this.timeout(15000);
-    var stan = STAN.connect(cluster, nuid.next(), {'url':'nats://localhost:' + PORT, 'reconnectTimeWait':20});
+    var stan = STAN.connect(cluster, nuid.next(), {
+      url:'nats://localhost:' + PORT,
+      reconnectTimeWait:20,
+      maxReconnectAttempts: 10
+    });
     stan.on('close', function() {
       (stan.nc.connected).should.equal(false, "nc should be closed");
       (stan.isClosed()).should.equal(false, "sc should not be closed");

--- a/test/stan_connection_lost.js
+++ b/test/stan_connection_lost.js
@@ -126,8 +126,6 @@ describe('Stan Server Ping Specific', function() {
 
   it('should get a "connection_lost" when replaced', function(done) {
     this.timeout(10000);
-
-
     var id = nuid.next();
     function connectClient(url, name) {
       var sc = STAN.connect(cluster, id, {


### PR DESCRIPTION
- Added (copied shamelessly) documentation from go-nats-streaming describing how the client ping mechanism works.

- Changed node-nats-streaming default for `maxReconnectAttempts` to be infinite on connections created by the stan client (matching the behavior of the go-nats-streaming client)

- Fixed tests that relied on `maxReconnectAttempts`.